### PR TITLE
Fixes json error field duplication

### DIFF
--- a/adapter.rb
+++ b/adapter.rb
@@ -16,7 +16,7 @@ def create_router(data)
   'router.create.vcloud.done'
 rescue StandardError => e
   puts e
-  data['error'] = { code: 0, message: e.to_s }
+  data[:error] = { code: 0, message: e.to_s }
   'router.create.vcloud.error'
 end
 


### PR DESCRIPTION
When an error occurs adapter is overloading the input json with "error"
field however this is accessed as string instead of symbol which becomes
on a duplication of error json field.
